### PR TITLE
Feature/cleanup mcp tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ Windows:
 3 - Install dependencies:
 
 ```bash
-
-uv pip install -e ".[dev]"
+pip install -e ".[dev]"
 ```
 
 4 - Copy and configure environment variables:

--- a/src/adls2_mcp_server/client.py
+++ b/src/adls2_mcp_server/client.py
@@ -19,7 +19,7 @@ class ADLS2Config:
     storage_account_key: Optional[str] = None
 
     @classmethod
-    def from_env(cls) -> "ADLS2Client":
+    def from_env(cls) -> "ADLS2Config":
         """Create a client from environment variables."""
         load_dotenv()
 

--- a/src/adls2_mcp_server/tools/directories.py
+++ b/src/adls2_mcp_server/tools/directories.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from typing import Dict, List
 
 logger = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ def register_directory_tools(mcp):
                 success=False,
                 error="Cannot create directory in read-only mode"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
         try:
             success = await mcp.client.create_directory(filesystem, path)
@@ -55,7 +55,7 @@ def register_directory_tools(mcp):
                 success=success,
                 error="" if success else "Failed to create directory"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error creating directory {path}: {e}")
             response = DirectoryResponse(
@@ -63,7 +63,7 @@ def register_directory_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="delete_directory",
@@ -85,7 +85,7 @@ def register_directory_tools(mcp):
                 success=False,
                 error="Cannot delete directory in read-only mode"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
         try:
             success = await mcp.client.delete_directory(filesystem, path)
@@ -94,7 +94,7 @@ def register_directory_tools(mcp):
                 success=success,
                 error="" if success else "Failed to delete directory"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error deleting directory {path}: {e}")
             response = DirectoryResponse(
@@ -102,7 +102,7 @@ def register_directory_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="rename_directory",
@@ -125,7 +125,7 @@ def register_directory_tools(mcp):
                 success=False,
                 error="Cannot rename directory in read-only mode"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
         try:
             success = await mcp.client.rename_directory(filesystem, source_path, destination_path)
@@ -134,7 +134,7 @@ def register_directory_tools(mcp):
                 success=success,
                 error="" if success else "Failed to rename directory"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error renaming directory {source_path} to {destination_path}: {e}")
             response = DirectoryResponse(
@@ -142,7 +142,7 @@ def register_directory_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="directory_exists",
@@ -165,7 +165,7 @@ def register_directory_tools(mcp):
                 exists=exists,
                 error=""
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error checking directory existence {path}: {e}")
             response = DirectoryExistsResponse(
@@ -173,7 +173,7 @@ def register_directory_tools(mcp):
                 exists=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="directory_get_paths",
@@ -197,11 +197,11 @@ def register_directory_tools(mcp):
                 paths=paths,
                 error=""
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error getting paths for directory {directory_path}: {e}")
             response = DirectoryPathsResponse(
                 path=directory_path,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)

--- a/src/adls2_mcp_server/tools/files.py
+++ b/src/adls2_mcp_server/tools/files.py
@@ -1,10 +1,12 @@
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from typing import Dict, Union
 
 logger = logging.getLogger(__name__)
 
+
+# Data class used to prevent the init inbuilt function and less boilerplate 
 @dataclass
 class FileResponse:
     source: str
@@ -77,7 +79,8 @@ def register_file_tools(mcp):
                 success=False,
                 error="Cannot upload file in read-only mode"
             )
-            return json.dumps(response.__dict__)
+            # TODO: add comment remove the json.dumps because we are returning a dict but no need for json because mcp serializes itself to json
+            return asdict(response)
 
         try:
             success = await mcp.client.upload_file(upload_file, filesystem, destination)
@@ -87,7 +90,7 @@ def register_file_tools(mcp):
                 success=success,
                 error="" if success else "Failed to upload file"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error uploading file {upload_file} to {destination}: {e}")
             response = FileResponse(
@@ -96,7 +99,7 @@ def register_file_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="download_file",
@@ -121,7 +124,7 @@ def register_file_tools(mcp):
                 success=success,
                 error="" if success else "Failed to download file"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error downloading file {source} to {download_path}: {e}")
             response = FileDownloadResponse(
@@ -130,7 +133,7 @@ def register_file_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="file_exists",
@@ -153,7 +156,7 @@ def register_file_tools(mcp):
                 exists=exists,
                 error=""
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error checking file existence {file_path}: {e}")
             response = FileExistsResponse(
@@ -161,7 +164,7 @@ def register_file_tools(mcp):
                 exists=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="rename_file",
@@ -185,7 +188,7 @@ def register_file_tools(mcp):
                 success=False,
                 error="Cannot rename file in read-only mode"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
         try:
             success = await mcp.client.rename_file(filesystem, source_path, destination_path)
@@ -195,7 +198,7 @@ def register_file_tools(mcp):
                 success=success,
                 error="" if success else "Failed to rename file"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error renaming file {source_path} to {destination_path}: {e}")
             response = FileRenameResponse(
@@ -204,7 +207,7 @@ def register_file_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="get_file_properties",
@@ -236,7 +239,7 @@ def register_file_tools(mcp):
                     success=False,
                     error="Failed to get file properties"
                 )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error getting properties for file {file_path}: {e}")
             response = FilePropertiesResponse(
@@ -245,7 +248,7 @@ def register_file_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="get_file_metadata",
@@ -277,7 +280,7 @@ def register_file_tools(mcp):
                     success=False,
                     error="Failed to get file metadata"
                 )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error getting metadata for file {file_path}: {e}")
             response = FileMetadataResponse(
@@ -286,7 +289,7 @@ def register_file_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="set_file_metadata",
@@ -310,7 +313,7 @@ def register_file_tools(mcp):
                 success=False,
                 error="Cannot set metadata in read-only mode"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
         try:
             success = await mcp.client.set_file_metadata(filesystem, file_path, key, value)
@@ -319,7 +322,7 @@ def register_file_tools(mcp):
                 success=success,
                 error="" if success else "Failed to set file metadata"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error setting metadata for file {file_path}: {e}")
             response = SetFileMetadataResponse(
@@ -327,7 +330,7 @@ def register_file_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="set_file_metadata_json",
@@ -350,7 +353,7 @@ def register_file_tools(mcp):
                 success=False,
                 error="Cannot set metadata in read-only mode"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
         try:
             # Convert metadata_json to string if it's a dictionary
@@ -363,7 +366,7 @@ def register_file_tools(mcp):
                 success=success,
                 error="" if success else "Failed to set file metadata"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error setting metadata for file {file_path}: {e}")
             response = SetFileMetadataResponse(
@@ -371,4 +374,4 @@ def register_file_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)

--- a/src/adls2_mcp_server/tools/filesystems.py
+++ b/src/adls2_mcp_server/tools/filesystems.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from typing import List, Dict
 
 logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
@@ -45,14 +45,14 @@ def register_filesystem_tools(mcp):
                 filesystems=fs,
                 error=""
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error listing filesystems: {e}")
             response = FilesystemListResponse(
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="create_filesystem",
@@ -73,7 +73,7 @@ def register_filesystem_tools(mcp):
                 success=False,
                 error="Cannot create filesystem in read-only mode"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
         try:
             success = await mcp.client.create_container(name)
@@ -82,7 +82,7 @@ def register_filesystem_tools(mcp):
                 success=success,
                 error="" if success else "Failed to create filesystem"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error creating filesystem {name}: {e}")
             response = CreateFilesystemResponse(
@@ -90,7 +90,7 @@ def register_filesystem_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
     @mcp.tool(
         name="delete_filesystem",
@@ -111,7 +111,7 @@ def register_filesystem_tools(mcp):
                 success=False,
                 error="Cannot delete filesystem in read-only mode"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
 
         try:
             success = await mcp.client.delete_filesystem(name)
@@ -120,7 +120,7 @@ def register_filesystem_tools(mcp):
                 success=success,
                 error="" if success else "Failed to delete filesystem"
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)
         except Exception as e:
             logger.error(f"Error deleting filesystem {name}: {e}")
             response = DeleteFilesystemResponse(
@@ -128,4 +128,4 @@ def register_filesystem_tools(mcp):
                 success=False,
                 error=str(e)
             )
-            return json.dumps(response.__dict__)
+            return asdict(response)


### PR DESCRIPTION
## What’s changed
- **Refactor handlers**: File & directory MCP tools now return native Python dicts via `asdict()` instead of pre-serializing with `json.dumps()`
- **Remove manual serialization**: All `json.dumps` calls removed—FastMCP handles JSON serialization automatically

## Why
- **Avoid double JSON encoding** in tool responses  
- **Leverage framework**: Rely on FastMCP’s built-in serialization for cleaner, more maintainable code  
